### PR TITLE
Reusable and standardize HTTP responses between API calls

### DIFF
--- a/specification/openapi/openapi_iri_facility_api_v1.json
+++ b/specification/openapi/openapi_iri_facility_api_v1.json
@@ -222,7 +222,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -232,7 +234,8 @@
             "required": false,
             "schema": {
               "type": "string",
-              "title": "The name of the resource."
+              "title": "The name of the resource.",
+              "minLength": 1
             }
           },
           {
@@ -242,7 +245,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -252,7 +257,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -261,7 +268,8 @@
             "description": "Return only resources of this type.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -398,7 +406,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -517,7 +527,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -526,7 +538,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -536,7 +549,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -546,7 +561,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -562,7 +579,8 @@
                 "degraded",
                 "down",
                 "unknown"
-              ]
+              ],
+              "minLength": 1
             }
           },
           {
@@ -577,7 +595,8 @@
                 "planned",
                 "unplanned",
                 "reservation"
-              ]
+              ],
+              "minLength": 1
             }
           },
           {
@@ -594,7 +613,8 @@
                 "completed",
                 "extended",
                 "pending"
-              ]
+              ],
+              "minLength": 1
             }
           },
           {
@@ -604,7 +624,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -614,7 +636,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -624,7 +648,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -761,7 +787,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -880,7 +908,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -889,7 +919,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -899,7 +930,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -909,7 +942,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -1031,7 +1066,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -1040,7 +1077,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -1050,7 +1088,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -1060,7 +1100,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -1081,7 +1123,8 @@
             "description": "Search for incidents/events that are active after (and including) the specified from time.  The from query parameter must be in ISO 8601 format with timezone offsets.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -1090,7 +1133,8 @@
             "description": "Search for incidents/events that are active before (and including) the specified 'to' time.  The from query parameter must be in ISO 8601 format with timezone offsets.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -1203,7 +1247,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -1322,7 +1368,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -1441,7 +1489,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -1560,7 +1610,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           }
         ],
@@ -1670,7 +1722,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -1679,7 +1733,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -1689,7 +1744,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -1699,7 +1756,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -1708,7 +1767,8 @@
             "description": "The short name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -1821,7 +1881,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -1940,7 +2002,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -2059,7 +2123,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -2068,7 +2134,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -2078,7 +2145,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -2088,7 +2157,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -2097,7 +2168,8 @@
             "description": "The short name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -2106,7 +2178,8 @@
             "description": "The country name in which a resource resides.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -2219,7 +2292,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -2404,7 +2479,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -2413,7 +2490,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -2423,7 +2501,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -2433,7 +2513,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           }
         ],
@@ -2546,7 +2628,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -2665,7 +2749,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -2674,7 +2760,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -2684,7 +2771,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -2694,7 +2783,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -2819,7 +2910,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -2938,7 +3031,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -2947,7 +3042,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -2957,7 +3053,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -2967,7 +3065,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -3089,7 +3189,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -3217,7 +3319,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -3226,7 +3330,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -3236,7 +3341,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -3246,7 +3353,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -3377,7 +3486,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -3514,7 +3625,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -3523,7 +3636,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -3533,7 +3647,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -3543,7 +3659,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           }
         ],
@@ -3656,7 +3774,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -3775,7 +3895,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -3784,7 +3906,8 @@
             "description": "The name of the resource.",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {
@@ -3794,7 +3917,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 0
+              "default": 0,
+              "minimum": 0,
+              "maximum": 1000
             }
           },
           {
@@ -3804,7 +3929,9 @@
             "required": false,
             "schema": {
               "type": "integer",
-              "default": 100
+              "default": 100,
+              "minimum": 0,
+              "maximum": 1000
             }
           }
         ],
@@ -3917,7 +4044,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "format": "date-time",
+              "minLength": 20,
+              "maxLength": 35
             }
           },
           {
@@ -4122,7 +4251,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "resource_type": {
             "type": "string",
@@ -4209,7 +4338,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "status": {
             "type": "string",
@@ -4314,7 +4443,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "status": {
             "type": "string",
@@ -4331,7 +4460,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this event occurred.  Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "resource_uri": {
             "type": "string",
@@ -4382,7 +4511,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "short_name": {
             "type": "string",
@@ -4509,7 +4638,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "short_name": {
             "type": "string",
@@ -4573,7 +4702,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "short_name": {
             "type": "string",
@@ -4698,7 +4827,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "user_id": {
             "type": "string",
@@ -4754,7 +4883,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "user_ids": {
             "type": "array",
@@ -4810,7 +4939,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "entries": {
             "type": "array",
@@ -4876,7 +5005,7 @@
             "type": "string",
             "format": "date-time",
             "description": "The date this resource was last modified. Format follows the ISO 8601 standard with timezone offsets.",
-            "example": "2025-03-11T07:28:24.000−00:00"
+            "example": "2025-03-11T07:28:24.000-00:00"
           },
           "units": {
             "type": "array",
@@ -4924,7 +5053,7 @@
         }
       },
       "BadRequest": {
-        "description": "Bad Request - The server due to malformed syntax or invalid query parameters could not understand the client’s request.",
+        "description": "Bad Request - The server due to malformed syntax or invalid query parameters could not understand the client's request.",
         "headers": {
           "Content-Type": {
             "description": "Provides media type used to encode the result of the operation.",

--- a/specification/openapi/openapi_iri_facility_api_v1.yaml
+++ b/specification/openapi/openapi_iri_facility_api_v1.yaml
@@ -189,6 +189,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
@@ -196,6 +198,7 @@ paths:
         schema:
           type: string
           title: The name of the resource.
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -204,6 +207,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -213,12 +218,15 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       - name: resource_type
         in: query
         description: Return only resources of this type.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: capability
         in: query
         description: Return only resources with this capability.
@@ -324,6 +332,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: resource_id
         in: path
         description: resource_id
@@ -417,12 +427,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -431,6 +444,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -440,6 +455,8 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       - name: status
         in: query
         description: The status of a resource.
@@ -452,6 +469,7 @@ paths:
           - degraded
           - down
           - unknown
+          minLength: 1
       - name: type
         in: query
         description: The type of incident.
@@ -463,6 +481,7 @@ paths:
           - planned
           - unplanned
           - reservation
+          minLength: 1
       - name: resolution
         in: query
         description: The type of resolution to the incident.
@@ -476,6 +495,7 @@ paths:
           - completed
           - extended
           - pending
+          minLength: 1
       - name: time
         in: query
         description: Search for incidents overlapping with time, where start <= time
@@ -485,6 +505,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: from
         in: query
         description: Search for incidents/events that are active after (and including)
@@ -494,6 +516,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: to
         in: query
         description: Search for incidents/events that are active before (and including)
@@ -503,6 +527,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: resource_uris
         in: query
         description: A list of resources to match.
@@ -608,6 +634,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: incident_id
         in: path
         description: incident_id
@@ -701,12 +729,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -715,6 +746,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -724,6 +757,8 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       - name: incident_id
         in: path
         description: incident_id
@@ -819,12 +854,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -833,6 +871,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -842,6 +882,8 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       - name: status
         in: query
         description: The status of a resource.
@@ -858,6 +900,7 @@ paths:
         required: false
         schema:
           type: string
+          minLength: 1
       - name: to
         in: query
         description: Search for incidents/events that are active before (and including)
@@ -866,6 +909,7 @@ paths:
         required: false
         schema:
           type: string
+          minLength: 1
       responses:
         '304':
           $ref: '#/components/responses/NotModified'
@@ -955,6 +999,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: event_id
         in: path
         description: event_id
@@ -1048,6 +1094,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: event_id
         in: path
         description: event_id
@@ -1141,6 +1189,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: event_id
         in: path
         description: event_id
@@ -1234,6 +1284,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       responses:
         '304':
           $ref: '#/components/responses/NotModified'
@@ -1321,12 +1373,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -1335,6 +1390,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -1344,12 +1401,15 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       - name: short_name
         in: query
         description: The short name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       responses:
         '200':
           description: OK - Returns a list of available IRI resources matching the
@@ -1439,6 +1499,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: site_id
         in: path
         description: The UUID uniquely identifying the IRI site resource.
@@ -1532,6 +1594,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: site_id
         in: path
         description: site_id
@@ -1625,12 +1689,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -1639,6 +1706,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -1648,18 +1717,22 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       - name: short_name
         in: query
         description: The short name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: country_name
         in: query
         description: The country name in which a resource resides.
         required: false
         schema:
           type: string
+          minLength: 1
       responses:
         '200':
           description: OK - Returns a list of available IRI resources matching the
@@ -1749,6 +1822,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: location_id
         in: path
         description: location_id
@@ -1892,12 +1967,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -1906,6 +1984,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -1915,6 +1995,8 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       responses:
         '200':
           description: OK - Returns a list of available IRI resources matching the
@@ -2004,6 +2086,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: user_allocation_id
         in: path
         description: The UUID uniquely identifying the IRI user allocation resource.
@@ -2097,12 +2181,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -2111,6 +2198,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -2120,6 +2209,8 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       - name: user_ids
         in: query
         description: Return only projects containing any of the listed users.
@@ -2217,6 +2308,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: project_id
         in: path
         description: The UUID uniquely identifying the IRI project resource.
@@ -2311,12 +2404,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -2325,6 +2421,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -2334,6 +2432,8 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       - name: project_id
         in: path
         description: The UUID uniquely identifying the IRI project resource.
@@ -2430,6 +2530,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: project_id
         in: path
         description: The UUID uniquely identifying the IRI project resource.
@@ -2529,12 +2631,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -2543,6 +2648,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -2552,6 +2659,8 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       - name: project_id
         in: path
         description: The UUID uniquely identifying the IRI project resource.
@@ -2655,6 +2764,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: project_id
         in: path
         description: The UUID uniquely identifying the IRI project resource.
@@ -2760,12 +2871,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -2774,6 +2888,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -2783,6 +2899,8 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       responses:
         '200':
           description: OK - Returns a list of available IRI resources matching the
@@ -2872,6 +2990,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: project_allocation_id
         in: path
         description: The UUID uniquely identifying the IRI project allocation resource.
@@ -2965,12 +3085,15 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: name
         in: query
         description: The name of the resource.
         required: false
         schema:
           type: string
+          minLength: 1
       - name: offset
         in: query
         description: An integer value specifying the starting number of resource to
@@ -2979,6 +3102,8 @@ paths:
         schema:
           type: integer
           default: 0
+          minimum: 0
+          maximum: 1000
       - name: limit
         in: query
         description: An integer value specifying the maximum number of resources to
@@ -2988,6 +3113,8 @@ paths:
         schema:
           type: integer
           default: 100
+          minimum: 0
+          maximum: 1000
       responses:
         '200':
           description: OK - Returns a list of available IRI resources matching the
@@ -3077,6 +3204,8 @@ paths:
         schema:
           type: string
           format: date-time
+          minLength: 20
+          maxLength: 35
       - name: capability_id
         in: path
         description: The UUID uniquely identifying the IRI capability resource.
@@ -3243,7 +3372,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         resource_type:
           type: string
           description: The type of resource.
@@ -3324,7 +3453,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         status:
           type: string
           description: The status of the Resource associated with this Incident.
@@ -3347,13 +3476,13 @@ components:
           format: date-time
           description: The date this Incident started, or is predicted to start. Format
             follows the ISO 8601 standard with timezone offsets.
-          example: 2023-10-17 11:02:31.690000+00:00
+          example: '2023-10-17T11:02:31.690000+00:00'
         end:
           type: string
           format: date-time
           description: The date this Incident ended, or is predicted to end.  Format
             follows the ISO 8601 standard with timezone offsets.
-          example: 2023-10-19 11:02:31.690000+00:00
+          example: '2023-10-19T11:02:31.690000+00:00'
         resolution:
           type: string
           default: pending
@@ -3420,7 +3549,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         status:
           type: string
           description: The status of the resource associated with this event.
@@ -3435,7 +3564,7 @@ components:
           format: date-time
           description: The date this event occurred.  Format follows the ISO 8601
             standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         resource_uri:
           type: string
           format: uri
@@ -3485,7 +3614,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         short_name:
           type: string
           description: The short name of the resource.
@@ -3602,7 +3731,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         short_name:
           type: string
           description: The short name of the resource.
@@ -3663,7 +3792,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         short_name:
           type: string
           description: The short name of the resource.
@@ -3768,7 +3897,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         user_id:
           type: string
           description: The user identifier associated with the allocation (hasUser).
@@ -3816,7 +3945,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         user_ids:
           type: array
           items:
@@ -3867,7 +3996,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         entries:
           type: array
           description: Allocation entries associated with this user allocation (hasAllocationEntry).
@@ -3926,7 +4055,7 @@ components:
           format: date-time
           description: The date this resource was last modified. Format follows the
             ISO 8601 standard with timezone offsets.
-          example: "2025-03-11T07:28:24.000\u221200:00"
+          example: '2025-03-11T07:28:24.000-00:00'
         units:
           type: array
           description: The list of AllocationUnit associated with this capability.
@@ -3965,8 +4094,8 @@ components:
           schema:
             type: string
     BadRequest:
-      description: "Bad Request - The server due to malformed syntax or invalid query\
-        \ parameters could not understand the client\u2019s request."
+      description: Bad Request - The server due to malformed syntax or invalid query
+        parameters could not understand the client's request.
       headers:
         Content-Type:
           description: Provides media type used to encode the result of the operation.


### PR DESCRIPTION
This change replaces all inline HTTP response definitions in the OpenAPI YAML/JSON with pre-defined reusable response values under `components.responses`. All HTTP Responses are now referenced to the same set of structured responses (200, 304, 400, 401, 403, 404, 405, 422, 500).

The update also standardizes the list of HTTP status codes returned by each API. Even if a specific endpoint does not raise a specific erroc code (e.g. 404), the responses are still included for consistency. Some errors might be introduced by outside layer, like reverse proxies, gateways, or might be in future extensions of API call. This aligns the API with common industry patterns (AWS, GitHub, Stripe) where standard http codes and schemas are defined centrally, and not under the individual operation.

This refactor does not change behavior of the API implementation. Next step, would be to create a dedicated errors.md file and describe general error responses.