### PR TITLE
capability.last_modified optional. Add spec compliance validator

### DIFF
--- a/specification/openapi/openapi_iri_facility_api_v1.json
+++ b/specification/openapi/openapi_iri_facility_api_v1.json
@@ -4845,7 +4845,6 @@
         },
         "required": [
           "id",
-          "last_modified",
           "name",
           "self_uri"
         ],

--- a/specification/openapi/openapi_iri_facility_api_v1.yaml
+++ b/specification/openapi/openapi_iri_facility_api_v1.yaml
@@ -3931,7 +3931,6 @@ components:
             $ref: '#/components/schemas/AllocationUnitType'
       required:
       - id
-      - last_modified
       - name
       - self_uri
       title: Capability

--- a/verification/README.MD
+++ b/verification/README.MD
@@ -20,6 +20,7 @@ This is intentionally lightweight and script-driven rather than a full test fram
 - Sends real HTTP requests to the API
 - Validates responses against the OpenAPI contract
 - Produces a single self-contained HTML report
+- In addition to runtime API validation, the validator can perform a specification compliance check (see Compliance verification)
 
 ---
 
@@ -73,6 +74,50 @@ python api-validator.py --baseurl https://iri.example.org
 This automatically resolves the schema as:
 ```
 https://example.org/openapi.json
+```
+
+---
+
+### Compliance verification
+
+```bash
+python api-validator.py --checkspeccompliance --official-schema ../specification/openapi/openapi_iri_facility_api_v1.yaml
+```
+
+The validator will do:
+
+- Loads the official IRI OpenAPI spec (as file yaml/json)
+- Fetches the facility’s live OpenAPI spec (localhost:8000)
+- Compares operations by operationId
+- Generate and print the report
+
+Report states:
+
+- **PASSED** - Operation exists in official and facility specs
+- **FAILED** - Operation exists in official spec but is missing in facility spec
+- **WARNING** - Operation exists in facility spec but not in official spec (extension, custom apis)
+
+Example output:
+
+```text
+Found in facility spec:
+-------------------------------------------------
+spec_compliance::[GET /api/v1/account/capabilities] PASSED
+spec_compliance::[GET /api/v1/account/capabilities/{capability_id}] PASSED
+spec_compliance::[GET /api/v1/facility] PASSED
+spec_compliance::[GET /api/v1/status/incidents/{incident_id}] PASSED
+-------------------------------------------------
+
+Not found in facility spec:
+-------------------------------------------------
+spec_compliance::[GET /api/v1/status/events/{event_id}] FAILED (missing operationId: getEvent)
+spec_compliance::[GET /api/v1/status/events] FAILED (missing operationId: getEvents)
+-------------------------------------------------
+
+Extra operationIds in facility spec not found in official spec:
+-------------------------------------------------
+spec_compliance::[DELETE /api/v1/compute/cancel/{resource_id}/{job_id}] WARNING (extra operationId: cancelJob)
+spec_compliance::[GET /api/v1/filesystem/checksum/{resource_id}] WARNING (extra operationId: checksum)
 ```
 
 ---

--- a/verification/api-validator.py
+++ b/verification/api-validator.py
@@ -4,6 +4,8 @@ import os
 import re
 import json
 import argparse
+import warnings
+import yaml
 import schemathesis
 import pytest
 
@@ -20,6 +22,8 @@ parser.add_argument("--baseurl", help="Base URL of the API under test. Default: 
 parser.add_argument("--schema-url", help="URL to the OpenAPI schema. Cannot be used with --schema-path. Default: <baseurl>/openapi.json")
 parser.add_argument("--schema-path", help="Path to the OpenAPI schema file. Cannot be used with --schema-url. Default: None")
 parser.add_argument("--report-name", help="Name of the HTML/XML report file. Default: schemathesis-report", default="schemathesis-report")
+parser.add_argument("--checkspeccompliance", action="store_true", help="Check facility spec compliance against official spec (operationIds)")
+parser.add_argument("--official-schema", help="Path or URL to the official OpenAPI schema")
 
 # parse_known_args so pytest flags are untouched
 args, _ = parser.parse_known_args()
@@ -36,20 +40,27 @@ if args.schema_url:
     SCHEMA_URL = args.schema_url
 if args.schema_path:
     SCHEMA_PATH = args.schema_path
-if not args.schema_url and not args.schema_path:
+if not args.schema_url and not args.schema_path and not args.checkspeccompliance:
     SCHEMA_URL = f"{BASE_URL}/openapi.json"
 
 # ---------------------------------------------------------------------------
 # Load schema BEFORE test definition
 # ---------------------------------------------------------------------------
-if SCHEMA_URL:
-    print(f"Loading schema from URL: {SCHEMA_URL}")
-    schema = schemathesis.openapi.from_url(SCHEMA_URL)
-else:
-    print(f"Loading schema from file: {SCHEMA_PATH}")
-    with open(SCHEMA_PATH, encoding="utf-8") as f:
-        raw_schema = json.load(f)
-    schema = schemathesis.openapi.from_dict(raw_schema)
+schema = None
+if not args.checkspeccompliance:
+    if SCHEMA_URL:
+        print(f"Loading schema from URL: {SCHEMA_URL}")
+        schema = schemathesis.openapi.from_url(SCHEMA_URL)
+    else:
+        print(f"Loading schema from file: {SCHEMA_PATH}")
+        with open(SCHEMA_PATH, encoding="utf-8") as fd:
+            try:
+                raw_schema = json.load(fd)
+            except json.JSONDecodeError as exc:
+                print(f"Failed to parse JSON, trying YAML load: {exc}")
+                fd.seek(0)
+                raw_schema = yaml.safe_load(fd)
+        schema = schemathesis.openapi.from_dict(raw_schema)
 
 # ---------------------------------------------------------------------------
 # Header sanitization (unchanged)
@@ -77,23 +88,108 @@ def before_call(ctx, case, kwargs):
     case.headers = clean
 
 # ---------------------------------------------------------------------------
-# Test definition (unchanged)
+# Spec compliance helpers
 # ---------------------------------------------------------------------------
-@schema.parametrize()
-def test_api(case):
-    response = case.call(
-        base_url=BASE_URL,
-        timeout=60,
-    )
-    case.validate_response(
-        response,
-        excluded_checks=[
-            schemathesis.checks.content_type_conformance,
-            schemathesis.checks.response_schema_conformance,
-            schemathesis.checks.unsupported_method,
-        ],
-    )
+def _load_schema(source):
+    if source.startswith("http://") or source.startswith("https://"):
+        return schemathesis.openapi.from_url(source).raw_schema
+    with open(source, encoding="utf-8") as fd:
+        try:
+            return json.load(fd)
+        except json.JSONDecodeError:
+            fd.seek(0)
+            return yaml.safe_load(fd)
 
+def _extract_operation_ids(schema_dict):
+    ops = {}
+    for path, methods in schema_dict.get("paths", {}).items():
+        for method, op in methods.items():
+            opid = op.get("operationId")
+            if opid:
+                ops[opid] = (path, method)
+    return ops
+
+# ---------------------------------------------------------------------------
+# Spec compliance test
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not args.checkspeccompliance, reason="Compliance mode not enabled")
+def test_spec_compliance():
+    if not args.official_schema:
+        pytest.fail("--official-schema must be provided with --checkspeccompliance")
+
+    official_schema = _load_schema(args.official_schema)
+    facility_schema = schemathesis.openapi.from_url(f"{BASE_URL}/openapi.json").raw_schema
+
+    official_ops = _extract_operation_ids(official_schema)
+    facility_ops = _extract_operation_ids(facility_schema)
+
+    missing = sorted(set(official_ops) - set(facility_ops))
+    extra = sorted(set(facility_ops) - set(official_ops))
+    present = sorted(set(official_ops) & set(facility_ops))
+
+    GREEN = "\033[1;92m"
+    RED = "\033[1;91m"
+    YELLOW = "\033[1;93m"
+    RESET = "\033[0m"
+
+    print("\n================ SPEC COMPLIANCE ================\n")
+
+    # PASSED
+    print("Found in facility spec:")
+    print("-------------------------------------------------")
+    for op in present:
+        path, method = official_ops[op]
+        print(f"spec_compliance::[{method.upper()} {path}] {GREEN}PASSED{RESET}")
+    print("-------------------------------------------------\n")
+    # FAILED
+    print("Not found in facility spec:")
+    print("-------------------------------------------------")
+    for op in missing:
+        path, method = official_ops[op]
+        print(f"spec_compliance::[{method.upper()} {path}] {RED}FAILED{RESET} (missing operationId: {op})")
+    print("-------------------------------------------------\n")
+
+    # WARNINGS (extra endpoints)
+    print("Extra operationIds in facility spec not found in official spec:")
+    print("-------------------------------------------------")
+    for op in extra:
+        path, method = facility_ops[op]
+        print(f"spec_compliance::[{method.upper()} {path}] {YELLOW}WARNING{RESET} (extra operationId: {op})")
+        warnings.warn(f"Extra operationId in facility spec not in official spec: {op} ({method.upper()} {path})")
+    print("-------------------------------------------------\n")
+
+    print("\n=================================================\n")
+
+    if missing:
+        pytest.fail(f"{len(missing)} official operationIds are missing from the facility spec")
+
+
+# ---------------------------------------------------------------------------
+# API validation test
+# ---------------------------------------------------------------------------
+if schema is None and not args.checkspeccompliance:
+    raise ValueError("Schema could not be loaded for API validation tests")
+if schema is not None:
+    @pytest.mark.skipif(args.checkspeccompliance, reason="Running spec compliance mode only")
+    @schema.parametrize()
+    def test_api(case):
+        """API validation test generated by Schemathesis."""
+        response = case.call(
+            base_url=BASE_URL,
+            timeout=60
+        )
+        case.validate_response(
+            response,
+            excluded_checks=[
+                schemathesis.checks.content_type_conformance,
+                schemathesis.checks.unsupported_method
+            ],
+        )
+else:
+    @pytest.mark.skip(reason="Schemathesis disabled in spec compliance mode")
+    def test_api():
+        """Dummy test when schemathesis is disabled."""
+        pass
 # ---------------------------------------------------------------------------
 # Pytest runner
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This includes for spec change:
- Remove `last_modified` from required fields for Capacity, but keep it defines as optional (https://github.com/doe-iri/iri-facility-api-docs/blob/main/specification/conceptual-model.md#644-capability - last_modified is optional)

This also includes new validation option (for more details see README.MD):
- Loads the official IRI OpenAPI spec (as file yaml/json)
- Fetches the facility’s live OpenAPI spec (localhost:8000)
- Compares operations by operationId
- Generate and print the report (Passed, failed, warning)